### PR TITLE
fixing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@
 
 For the most up-to-date and comprehensive documentation, please visit our GitBook:
 
-[![GitBook Documentation](https://img.shields.io/badge/GitBook-Documentation-blue?style=for-the-badge\&logo=gitbook)](https://lightning-bounties.gitbook.io/docs/getting-started/getting-started)
+[![GitBook Documentation](https://img.shields.io/badge/GitBook-Documentation-blue?style=for-the-badge\&logo=gitbook)](https://docs.lightningbounties.com/docs/)
 
 ### 💰 Open Bounties on Our Documentation
 
 We're constantly looking to improve our documentation, and we pay in sats for valuable contributions!
 
-[![View Open Bounties](https://img.shields.io/badge/View%20Open%20Bounties-orange?style=for-the-badge)](https://beta.lightningbounties.com)
+[![View Open Bounties](https://img.shields.io/badge/View%20Open%20Bounties-orange?style=for-the-badge)](https://app.lightningbounties.com)
 
-You can also check the [Issues tab](https://github.com/MIT-Bitcoin-2024/demo-gitbook/issues) on this repo for specific tasks.
+You can also check the [Issues tab](https://github.com/Lightning-Bounties/docs/issues) on this repo for specific tasks.
 
 ### 🚀 How to Contribute
 
-1. **Find an open bounty** on our [beta platform](https://beta.lightningbounties.com) or in the [Issues tab](https://github.com/MIT-Bitcoin-2024/demo-gitbook/issues).
+1. **Find an open bounty** on our [bounty platform](https://app.lightningbounties.com) or in the [Issues tab](https://github.com/Lightning-Bounties/docs/issues).
 2. **Fork this repository** and create a new branch for your work.
 3. **Make your changes** and commit them with clear, concise commit messages.
 4. **Submit a Pull Request** with a detailed description of your changes.
@@ -50,7 +50,7 @@ Have questions? Want to discuss a bounty?
 
 ### 📜 License
 
-This project is licensed under the \[[MIT License](https://github.com/MIT-Bitcoin-2024/demo-gitbook?tab=License-1-ov-file)]
+This project is licensed under the \[[MIT License](https://github.com/Lightning-Bounties/docs?tab=License-1-ov-file)]
 
 ### :handshake: Supporters
 


### PR DESCRIPTION
close #1 

* [x]  link to gitbook deploy (should be docs.lb.com)
* [x]  both links to app deploy  (should be app.lb.com)
* [x]  link to issues (should refer to this current repo)
* [x]  any others on the README.md **found one in license section**
