### PR TITLE
Add Guide for Converting Sats to Mexican Pesos

### DIFF
--- a/solve-a-bounty/how-to-convert-sats-into-local-currencies.md
+++ b/solve-a-bounty/how-to-convert-sats-into-local-currencies.md
@@ -6,24 +6,24 @@ To withdraw Sats from the Lightning Network to Coinbase (or any other wallet/exc
 
 ## <mark style="background-color:green;">**Part (1):**</mark>** Receiving Bitcoin via Lightning**
 
-***
+---
 
 1. Sign in to your Coinbase account.
 2. Select **Bitcoin** as the asset you wish to receive.
 3. Select the Lightning network.
 4. Follow the prompts to create your invoice
-   * Invoices are valid for 72 hours.
+   - Invoices are valid for 72 hours.
 5. Copy the invoice. You will need this in the next section.
 
 {% embed url="https://youtube.com/shorts/5ztvoJlsCu0" fullWidth="true" %}
 
-***
+---
 
 ## <mark style="background-color:green;">**Part (2):**</mark>** How to withdraw sats from Lightning Bounties to Coinbase?**
 
-***
+---
 
-1. **Login to Lightning Bounties:**  then click on your account.
+1. **Login to Lightning Bounties:** then click on your account.
 
 ![Step #1 ](../.gitbook/assets/step1.png)
 
@@ -33,7 +33,7 @@ To withdraw Sats from the Lightning Network to Coinbase (or any other wallet/exc
 
 3a. First, paste your invoice string into the input field&#x20;
 
-&#x20;    [  _(the same one you copied on your Coinbase account in the previous step)._  ](how-to-convert-sats-into-local-currencies.md#getting-started)
+&#x20; [ _(the same one you copied on your Coinbase account in the previous step)._ ](how-to-convert-sats-into-local-currencies.md#getting-started)
 
 3b. Click the “Create”
 
@@ -41,13 +41,9 @@ To withdraw Sats from the Lightning Network to Coinbase (or any other wallet/exc
 
 4. Your sats should now be reflected in your Coinbase account after the transaction is confirmed.
 
-***
-
-
+---
 
 ## <mark style="background-color:green;">**Part (3):**</mark>** Converting Your Crypto Into Fiat Using Coinbase.**&#x20;
-
-
 
 {% hint style="info" %}
 Before you can cash out your crypto, you may need to sell it to your Coinbase cash balance before transferring the cash to your bank. You can then either transfer ("cash out") the funds to your bank or leave them in your cash balance for future crypto purchases. There's no limit on the amount of crypto you can sell for cash.
@@ -62,11 +58,12 @@ Before you can cash out your crypto, you may need to sell it to your Coinbase ca
 1. Sign in to your Coinbase account, on the web or mobile app
 2. Select **Buy & Sell**
 3. Select **Sell**
-4.  Select the crypto you want to sell and the amount.
+4. Select the crypto you want to sell and the amount.
 
-    _<mark style="color:yellow;">If on mobile, you'll be required to crypto the asset you want to sell before entering an amount</mark>_
+   _<mark style="color:yellow;">If on mobile, you'll be required to crypto the asset you want to sell before entering an amount</mark>_
+
 5. Change the **To** destination, if applicable.
-   * This will likely default to your local currency balance (USD) but you may have the option of adding to another balance (e.g., USDC).
+   - This will likely default to your local currency balance (USD) but you may have the option of adding to another balance (e.g., USDC).
 6. Select **Review order.**
 7. Select **Sell now** to complete the sale.
 
@@ -84,3 +81,39 @@ Once the crypto sell order is complete, the funds will be available in your cash
 | <ol start="6"><li>Select <strong>Review.</strong></li></ol>                                                    | <ol start="6"><li>Select <strong>Cash out now</strong> to complete your transfer.</li></ol>                                            |
 | <ol start="7"><li>Select <strong>Withdraw cash</strong> to complete your transfer.</li></ol>                   |                                                                                                                                        |
 
+## <mark style="background-color:green;">**Part (3):**</mark>** Converting Sats to Mexican Pesos Using Coinbase.**&#x20;
+
+1. **Create a Coinbase Account**:
+
+   - Visit [Coinbase](https://www.coinbase.com/) and sign up for an account if you don't have one.
+
+2. **Verify Your Identity**:
+
+   - Complete the identity verification process as required by Coinbase.
+
+3. **Deposit Bitcoin**:
+
+   - Transfer your Bitcoin (BTC) to your Coinbase wallet. You can do this by selecting "Accounts" and then "Receive" to get your wallet address.
+
+4. **Convert BTC to MXN**:
+
+   - Once your Bitcoin is in your Coinbase wallet, go to the "Trade" section.
+   - Select "Convert" and choose Bitcoin (BTC) as the asset you want to convert.
+   - Choose Mexican Pesos (MXN) as the currency you want to convert to.
+   - Enter the amount of BTC you wish to convert and review the conversion details.
+   - Confirm the conversion.
+
+5. **Withdraw to Your Bank Account**:
+   - After converting to MXN, go to the "Accounts" tab.
+   - Select your MXN wallet and click on "Withdraw".
+   - Choose your bank account and enter the amount you want to withdraw.
+   - Confirm the withdrawal.
+
+## <mark style="background-color:green;">**Part (3):**</mark>** What to Do with Sats Without Converting to Fiat.**&#x20;
+
+- **Use for Online Purchases**: Some merchants accept Sats directly.
+- **Invest in Other Cryptocurrencies**: Use your sats to invest in altcoins.
+- **Donate to Charities**: Many organizations accept Bitcoin donations.
+- **Hold as an Investment**: Consider holding your sats for potential future value appreciation.
+
+Visit [SatsConverter](https://satsconverter.io/) and see what your sats are worth in local currencies.


### PR DESCRIPTION
#Description:
This PR addresses issue #5 by adding a comprehensive guide on converting Bitcoin (sats) to Mexican Pesos. 


#The key updates include:
How-to Guide: Detailed steps for converting sats into local currency using coinbase.
Resources: Links to relevant tools and services for conversion.

#Motivation:
This change aims to provide users with clear instructions on how to convert their Bitcoin holdings into Mexican Pesos, facilitating easier access to local currency.

Added few things to do with Sats Without Converting to Fiat

Related Issues:
Closes #5
---



