### PR TITLE
docs: add guide on converting sats to MXN for Mexican users

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,6 +12,7 @@
   * [Withdrawing Funds](getting-started/solving-a-bounty/withdraw-funds.md)
   * [Working on Opensource Frontend: lb-next](getting-started/solving-a-bounty/working-on-opensource-frontend-lb-next.md)
   * [How to Convert Sats into Local Currencies](getting-started/solving-a-bounty/how-to-convert-sats-into-local-currencies.md)
+  * [Convert Sats to MXN (Mexico)](docs/solve-a-bounty/sats-to-mxn.md)
 * [POSTING A BOUNTY](getting-started/posting-a-bounty/README.md)
   * [Deposit Funds](getting-started/posting-a-bounty/deposit-funds.md)
   * [Create a GitHub issue and Submit a new reward](getting-started/posting-a-bounty/create-a-github-issue-and-submit-a-new-reward.md)

--- a/docs/solve-a-bounty/sats-to-mxn.md
+++ b/docs/solve-a-bounty/sats-to-mxn.md
@@ -1,0 +1,72 @@
+# How to Convert Sats into Mexican Pesos (MXN)
+
+Once you've earned satoshis (sats) through Lightning Bounties, you might want to convert them into your local currency. This guide covers how to convert your sats into Mexican Pesos (MXN) and transfer them directly into your bank account.
+
+## Overview
+
+Converting sats to MXN generally involves these steps:
+1. Sending sats from your Lightning wallet to a crypto exchange that supports MXN.
+2. Selling the sats (or Bitcoin) for Mexican Pesos within the exchange.
+3. Withdrawing the Mexican Pesos via SPEI transfer to your local bank account.
+
+---
+
+## Recommended Exchanges for Mexico
+
+Two of the most popular and reliable exchanges supporting both the Lightning Network (for low fees) and MXN withdrawals (via SPEI) are:
+
+- **Bitso** (The largest crypto exchange in Mexico, supports SPEI transfers).
+- **Strike** (Supports Lightning Network natively and allows cross-border fiat payouts).
+- **Binance** (Global platform with P2P options or MXN fiat gateways).
+
+Below is a step-by-step example using **Bitso**.
+
+---
+
+## Step-by-Step Guide: Using Bitso
+
+### 1. Set Up Your Bitso Account
+If you do not already have a Bitso account, download the app or visit Bitso.com to create one.
+* **Verify your identity (KYC):** You will need to provide identification to enable fiat withdrawals to your bank.
+
+### 2. Get Your Bitcoin Deposit Address
+Since you have satoshis on the Lightning Network, you need to ensure you deposit via the correct network.
+
+1. Open the Bitso app and select **Deposit**.
+2. Choose **Bitcoin (BTC)**.
+3. Make sure to select the **Lightning Network** option (if available) to save on fees.
+4. If Bitso only supports regular on-chain Bitcoin deposits for your account tier, you may need a wallet like *Muun* or *Breez* to swap Lightning sats to an on-chain BTC address seamlessly.
+5. Copy your deposit address or generate a Lightning invoice for the specific amount.
+
+### 3. Send Sats from Your Wallet
+1. Open the wallet where you received your Lightning Bounties (e.g., Wallet of Satoshi, Zeus, Alby).
+2. Click **Send**.
+3. Paste the invoice or address from Bitso.
+4. Confirm the transaction. It should arrive almost instantly if using the Lightning Network.
+
+### 4. Sell Crypto for MXN
+1. On Bitso, go to your **Wallet** or **Exchange** tab.
+2. Select your Bitcoin balance and choose **Sell** or **Convert**.
+3. Enter the amount of BTC you want to sell and choose **MXN (Mexican Pesos)** as the receiving currency.
+4. Review the exchange rate and confirm the sale.
+
+### 5. Withdraw MXN via SPEI
+1. Go back to the main menu and select **Send** or **Withdraw**.
+2. Choose **Mexican Pesos (MXN)**.
+3. Select **Bank transfer (SPEI)**.
+4. Enter your 18-digit CLABE number (the standard for Mexican bank transfers), the bank name, and the beneficiary name.
+5. Enter the amount you wish to withdraw and confirm. 
+6. SPEI transfers are processed 24/7 and usually arrive in your bank account within minutes!
+
+---
+
+## Bonus: What to Do with Sats Without Converting!
+
+Instead of converting your sats to fiat, did you know you can spend them directly in Mexico or online? Here are a few ways to use your sats:
+
+* **Pay for Bills + Services:** Use services like Bitrefill to buy gift cards for Amazon MX, Uber, cellular top-ups (Telcel, AT/T), and more, directly with Lightning.
+* **Support Creators:** Use the Alby extension or apps like Nostr to tip your favorite podcasters, writers, and developers who accept Zaps.
+* **Shop at Lightning-friendly stores:** An increasing number of online merchants accept Bitcoin via Lightning. Check out directories like Lightning Network Stores.
+* **Save/HODL:** Keep your sats in a secure self-custodial wallet as a long-term digital asset.
+
+By keeping your funds in the Bitcoin ecosystem, you completely avoid exchange fees and bank withdrawal limits.

--- a/getting-started/solving-a-bounty/how-to-convert-sats-into-local-currencies.md
+++ b/getting-started/solving-a-bounty/how-to-convert-sats-into-local-currencies.md
@@ -1,5 +1,7 @@
 # How to Convert Sats into Local Currencies
 
+- [Sats to MXN (Mexico)](../../docs/solve-a-bounty/sats-to-mxn.md)
+
 ## Getting Started
 
 To withdraw Sats from the Lightning Network to Coinbase (or any other wallet/exchange), follow these steps. The process remains similar no matter where you're transferring your funds.


### PR DESCRIPTION
Closes #5. Added a markdown guide explaining how to convert satoshis to Mexican pesos using Bitso and transferring via SPEI, with a bonus section describing apps and platforms where users can spend sats without converting. Linked the new file in the SUMMARY index and the root local-currencies guide.